### PR TITLE
test(eth-proofs): Fix and test Eth proofs on NEAR

### DIFF
--- a/eth-prover/src/tests.rs
+++ b/eth-prover/src/tests.rs
@@ -27,9 +27,6 @@ mod tests {
         }
     }
 
-    // TESTS
-
-    use borsh::BorshSerialize;
     use near_sdk::MockedBlockchain;
     use near_sdk::{testing_env, VMContext};
 
@@ -80,7 +77,7 @@ mod tests {
             stream.append(item);
         }
         stream.out()
-    }).collect();
+    }).collect::<Vec<Vec<u8>>>();
 
         if let PromiseOrValue::Value(true) = contract.verify_log_entry(
             log_index,


### PR DESCRIPTION
The logic for proof verification currently has some drawbacks.
The logic to verifacate proofs from the Ethereum blockchain
in the NEAR side of the bridge was improved with:

- Handle all types of keys, previously it was only possible to
    prove receipts and transactions, now also state can be proved.

- It doesn't use unrecoverable erros anymore to mark an invalid
    proof, instead it always return boolean value.

- Some nits in the code.

The main resources used to understand and implement the verification was:
- https://eth.wiki/en/fundamentals/patricia-tree
- https://eth.wiki/fundamentals/rlp

Test plan
=========
- Verify all recipts and transaction from the Ethereum blockchain up to some point can be validated.
- Verify state/storage proofs can be validated with real data extracted from Ethereum.
- `verify_trie_proof` code has 100% coverage. 